### PR TITLE
re-do infer_filetype() to fix numerous bugs

### DIFF
--- a/lib/rpki/sqhl.c
+++ b/lib/rpki/sqhl.c
@@ -294,32 +294,59 @@ static int dupsigscm(
     }
 }
 
+/**
+ * @brief
+ *     test whether a string has a particular suffix
+ */
+static _Bool
+ends_with(
+    const char *str,
+    size_t lenstr,
+    const char *sfx,
+    size_t lensfx)
+{
+    assert(str);
+    assert(sfx);
+    if (lensfx > lenstr)
+        return 0;
+    return (0 == strncmp(str + lenstr - lensfx, sfx, lensfx));
+}
+
 int infer_filetype(
     const char *fname)
 {
-    int pem = 0;
-    int typ = 0;
+    struct {
+        const char *const sfx;
+        const size_t lensfx;
+        const int typ;
+    } *rulep, rules[] = {
+        {".cer", 4, OT_CER},
+        {".crl", 4, OT_CRL},
+        {".roa", 4, OT_ROA},
+        {".man", 4, OT_MAN},
+        {".mft", 4, OT_MAN},
+        {".mnf", 4, OT_MAN},
+        {".gbr", 4, OT_GBR},
+        {".cer.pem", 8, OT_CER_PEM},
+        {".crl.pem", 8, OT_CRL_PEM},
+        {".roa.pem", 8, OT_ROA_PEM},
+        {".man.pem", 8, OT_MAN_PEM},
+        {".mft.pem", 8, OT_MAN_PEM},
+        {".mnf.pem", 8, OT_MAN_PEM},
+        {NULL, 0, OT_UNKNOWN} // must be last
+    };
 
     assert(fname);
 
-    if (strstr(fname, ".pem") != NULL)
-        pem = 1;
-    if (strstr(fname, ".cer") != NULL)
-        typ += OT_CER;
-    if (strstr(fname, ".crl") != NULL)
-        typ += OT_CRL;
-    if (strstr(fname, ".roa") != NULL && !typ)
-        typ += OT_ROA;
-    if ((strstr(fname, ".man") != NULL || strstr(fname, ".mft") != NULL ||
-         strstr(fname, ".mnf") != NULL) && !typ)
-        typ += OT_MAN;
-    if (strstr(fname, ".gbr") != NULL)
-        typ += OT_GBR;
-    if (typ < OT_UNKNOWN || typ > OT_MAXBASIC)
-        return (ERR_SCM_INVALFN);
-    if (pem > 0)
-        typ += OT_PEM_OFFSET;
-    return (typ);
+    size_t lenfname = strlen(fname);
+
+    for (rulep = &rules[0]; rulep->sfx; ++rulep)
+    {
+        if (ends_with(fname, lenfname, rulep->sfx, rulep->lensfx))
+            return rulep->typ;
+    }
+    // return the type in the NULL rule
+    return rulep->typ;
 }
 
 // so that manifest can get id of previous cert

--- a/lib/rpki/sqhl.c
+++ b/lib/rpki/sqhl.c
@@ -295,7 +295,7 @@ static int dupsigscm(
 }
 
 int infer_filetype(
-    char *fname)
+    const char *fname)
 {
     int pem = 0;
     int typ = 0;

--- a/lib/rpki/sqhl.c
+++ b/lib/rpki/sqhl.c
@@ -294,17 +294,6 @@ static int dupsigscm(
     }
 }
 
-/*
- * Infer the object type based on which file extensions are present. The
- * following can be present: .cer, .crl and .roa; .pem can also be present. If
- * there is no suffix, then also check to see if the filename is of the form
- * HHHHHHHH.N, where "HHHHHHHH" is eight hex digits, and .N is an integer
- * suffix. In this case, it is a cert. If nothing can be determined then
- * return unknown.
- *
- * On success this function returns one of the types defined in sqhl.h; on
- * failure it returns a negative error code.
- */
 int infer_filetype(
     char *fname)
 {

--- a/lib/rpki/sqhl.c
+++ b/lib/rpki/sqhl.c
@@ -296,16 +296,15 @@ static int dupsigscm(
 
 /*
  * Infer the object type based on which file extensions are present. The
- * following can be present: .cer, .crl and .roa; .pem can also be present. If 
+ * following can be present: .cer, .crl and .roa; .pem can also be present. If
  * there is no suffix, then also check to see if the filename is of the form
  * HHHHHHHH.N, where "HHHHHHHH" is eight hex digits, and .N is an integer
  * suffix. In this case, it is a cert. If nothing can be determined then
  * return unknown.
- * 
+ *
  * On success this function returns one of the types defined in sqhl.h; on
- * failure it returns a negative error code. 
+ * failure it returns a negative error code.
  */
-
 int infer_filetype(
     char *fname)
 {

--- a/lib/rpki/sqhl.c
+++ b/lib/rpki/sqhl.c
@@ -300,8 +300,7 @@ int infer_filetype(
     int pem = 0;
     int typ = 0;
 
-    if (fname == NULL)
-        return (ERR_SCM_INVALARG);
+    assert(fname);
 
     if (strstr(fname, ".pem") != NULL)
         pem = 1;

--- a/lib/rpki/sqhl.c
+++ b/lib/rpki/sqhl.c
@@ -3652,8 +3652,6 @@ int add_object(
         return (sta);
     // determine its filetype
     typ = infer_filetype(outfull);
-    if (typ < 0)
-        return (typ);
     // find or add the directory
     sta = findorcreatedir(scmp, conp, outdir, &id);
     if (sta < 0)
@@ -4018,8 +4016,6 @@ int delete_object(
         return (ERR_SCM_INVALARG);
     // determine its filetype
     typ = infer_filetype(outfile);
-    if (typ < 0)
-        return (typ);
     // find the directory
     if (scmp)
         initTables(scmp);       // may be null if tables have been initiated

--- a/lib/rpki/sqhl.c
+++ b/lib/rpki/sqhl.c
@@ -300,7 +300,7 @@ int infer_filetype(
     int pem = 0;
     int typ = 0;
 
-    if (fname == NULL || fname[0] == 0)
+    if (fname == NULL)
         return (ERR_SCM_INVALARG);
 
     if (strstr(fname, ".pem") != NULL)

--- a/lib/rpki/sqhl.h
+++ b/lib/rpki/sqhl.h
@@ -99,8 +99,9 @@ extern int delete_object(
  * @brief
  *     Infer the object type based on which file extensions are present.
  *
- * The following can be present: .cer, .crl and .roa; .pem can also be
- * present.  If nothing can be determined then return unknown.
+ * The following can be present: .cer, .crl, .roa, .man, .mft, .mnf,
+ * and .gbr; .pem can also be present.  If nothing can be determined
+ * then return unknown.
  *
  * @return
  *     On success this function returns one of the types defined in

--- a/lib/rpki/sqhl.h
+++ b/lib/rpki/sqhl.h
@@ -95,16 +95,19 @@ extern int delete_object(
     char *outfull,
     unsigned int dir_id);
 
-/*
- * Infer the object type based on which file extensions are present. The
- * following can be present: .cer, .crl and .roa; .pem can also be present. If
- * there is no suffix, then also check to see if the filename is of the form
- * HHHHHHHH.N, where "HHHHHHHH" is eight hex digits, and .N is an integer
- * suffix. In this case, it is a cert. If nothing can be determined then
- * return unknown.
+/**
+ * @brief
+ *     Infer the object type based on which file extensions are present.
  *
- * On success this function returns one of the types defined in sqhl.h; on
- * failure it returns a negative error code.
+ * The following can be present: .cer, .crl and .roa; .pem can also be
+ * present.  If there is no suffix, then also check to see if the
+ * filename is of the form HHHHHHHH.N, where "HHHHHHHH" is eight hex
+ * digits, and .N is an integer suffix.  In this case, it is a cert.
+ * If nothing can be determined then return unknown.
+ *
+ * @return
+ *     On success this function returns one of the types defined in
+ *     sqhl.h; on failure it returns a negative error code.
  */
 extern int infer_filetype(
     char *fname);

--- a/lib/rpki/sqhl.h
+++ b/lib/rpki/sqhl.h
@@ -100,10 +100,7 @@ extern int delete_object(
  *     Infer the object type based on which file extensions are present.
  *
  * The following can be present: .cer, .crl and .roa; .pem can also be
- * present.  If there is no suffix, then also check to see if the
- * filename is of the form HHHHHHHH.N, where "HHHHHHHH" is eight hex
- * digits, and .N is an integer suffix.  In this case, it is a cert.
- * If nothing can be determined then return unknown.
+ * present.  If nothing can be determined then return unknown.
  *
  * @return
  *     On success this function returns one of the types defined in

--- a/lib/rpki/sqhl.h
+++ b/lib/rpki/sqhl.h
@@ -111,7 +111,7 @@ extern int delete_object(
  *     sqhl.h; on failure it returns a negative error code.
  */
 extern int infer_filetype(
-    char *fname);
+    const char *fname);
 
 extern int add_cert(
     scm * scmp,

--- a/lib/rpki/sqhl.h
+++ b/lib/rpki/sqhl.h
@@ -99,16 +99,21 @@ extern int delete_object(
  * @brief
  *     Infer the object type based on which file extensions are present.
  *
- * The following can be present: .cer, .crl, .roa, .man, .mft, .mnf,
- * and .gbr; .pem can also be present.  If nothing can be determined
- * then return unknown.
- *
  * @param[in] fname
  *     File pathname.  This MUST NOT be NULL.
  *
  * @return
- *     On success this function returns one of the types defined in
- *     sqhl.h; on failure it returns a negative error code.
+ *     An object type code depending on the filename suffix:
+ *       - `.cer`: ::OT_CER
+ *       - `.crl`: ::OT_CRL
+ *       - `.roa`: ::OT_ROA
+ *       - `.man`, `.mft`, `.mnf`: ::OT_MAN
+ *       - `.gbr`: ::OT_GBR
+ *       - `.cer.pem`: ::OT_CER_PEM
+ *       - `.crl.pem`: ::OT_CRL_PEM
+ *       - `.roa.pem`: ::OT_ROA_PEM
+ *       - `.man.pem`, `.mft.pem`, `.mnf.pem`: ::OT_MAN_PEM
+ *       - all others: ::OT_UNKNOWN.
  */
 extern int infer_filetype(
     const char *fname);

--- a/lib/rpki/sqhl.h
+++ b/lib/rpki/sqhl.h
@@ -104,7 +104,7 @@ extern int delete_object(
  * then return unknown.
  *
  * @param[in] fname
- *     File pathname.  This MUST be a non-empty string.
+ *     File pathname.  This MUST NOT be NULL.
  *
  * @return
  *     On success this function returns one of the types defined in

--- a/lib/rpki/sqhl.h
+++ b/lib/rpki/sqhl.h
@@ -95,6 +95,17 @@ extern int delete_object(
     char *outfull,
     unsigned int dir_id);
 
+/*
+ * Infer the object type based on which file extensions are present. The
+ * following can be present: .cer, .crl and .roa; .pem can also be present. If
+ * there is no suffix, then also check to see if the filename is of the form
+ * HHHHHHHH.N, where "HHHHHHHH" is eight hex digits, and .N is an integer
+ * suffix. In this case, it is a cert. If nothing can be determined then
+ * return unknown.
+ *
+ * On success this function returns one of the types defined in sqhl.h; on
+ * failure it returns a negative error code.
+ */
 extern int infer_filetype(
     char *fname);
 

--- a/lib/rpki/sqhl.h
+++ b/lib/rpki/sqhl.h
@@ -94,8 +94,10 @@ extern int delete_object(
     char *outdir,
     char *outfull,
     unsigned int dir_id);
+
 extern int infer_filetype(
     char *fname);
+
 extern int add_cert(
     scm * scmp,
     scmcon * conp,

--- a/lib/rpki/sqhl.h
+++ b/lib/rpki/sqhl.h
@@ -103,6 +103,9 @@ extern int delete_object(
  * and .gbr; .pem can also be present.  If nothing can be determined
  * then return unknown.
  *
+ * @param[in] fname
+ *     File pathname.  This MUST be a non-empty string.
+ *
  * @return
  *     On success this function returns one of the types defined in
  *     sqhl.h; on failure it returns a negative error code.


### PR DESCRIPTION
  * only check the filename suffix (don't permit the extension to be in the middle of the pathname) to avoid nonsensical values for pathnames such as `foo.manager/bar.gbr`
  * avoid the confusing additive logic that yielded nonsensical values for pathnames such as `foo.gbr.cer`
  * require `.pem` to be after the other suffix
  * use clear logic to make the function's behavior easier to understand

Also miscellaneous fixes/cleanups:
  * `const`ify the parameter
  * Doxygenize the documentation
  * never return a negative error code (there's no need, and it makes it possible to convert the return type to an enum type in the future)

Addresses issue #31.