### PR TITLE
Autoconf fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -237,6 +237,14 @@ AC_LINK_IFELSE(
 flags_restore
 
 ######################################################################
+# libdl
+######################################################################
+flags_declare_addons([[LIBDL_]])
+RPSTIR_SEARCH_LIBS([dlopen], [dl], [LIBDL_], [], [], [
+    AC_MSG_ERROR([libdl is required for building this project])
+  ])
+
+######################################################################
 # OpenSSL
 ######################################################################
 flags_declare_addons([[OPENSSL_]])
@@ -260,11 +268,13 @@ AC_ARG_WITH(
 AS_IF([test x${ssl_lib} != x], [
     OPENSSL_LDFLAGS="-L${ssl_lib} -Wl,-rpath -Wl,${ssl_lib}"
   ])
+flags_load_addons([[LIBDL_]])
 flags_load_addons([[OPENSSL_]])
 RPSTIR_SEARCH_LIBS([X509_VERIFY_PARAM_free], [crypto], [OPENSSL_], [], [], [
     AC_MSG_ERROR([OpenSSL is required for building this project])
   ])
 flags_restore
+flags_load_addons([[LIBDL_]])
 flags_load_addons([[OPENSSL_]])
 RPSTIR_SEARCH_LIBS([v3_addr_validate_path], [crypto], [OPENSSL_],
   ["${ac_cv_search_X509_VERIFY_PARAM_free}"], [], [
@@ -335,20 +345,12 @@ RPSTIR_SEARCH_LIBS([cryptInit], [cl], [CRYPTLIB_], [], [], [
   ])
 flags_restore
 
-######################################################################
-# libdl
-######################################################################
-flags_declare_addons([[LIBDL_]])
-RPSTIR_SEARCH_LIBS([dlopen], [dl], [LIBDL_], [], [], [
-    AC_MSG_ERROR([libdl is required for building this project])
-  ])
-
 # add all of the library-specific flags to the CONFIGURE_* flags
 #
 # TODO: delete this and instead reference the library-specific flag
 # variables from the appropriate *_LDFLAGS, *_LIBADD, *_LDADD,
 # *_CPPFLAGS variables in Makefile.am
-m4_foreach_w([lib], [[MYSQL] [OPENSSL] [ODBC] [CRYPTLIB] [LIBDL]], [
+m4_foreach_w([lib], [[MYSQL] [LIBDL] [OPENSSL] [ODBC] [CRYPTLIB]], [
     flags_load_addons([lib[_]], [[CONFIGURE_]])
   ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -170,7 +170,7 @@ m4_define([flags_restore], [
 # the macro, append (or prepend) to $2foo instead of foo.
 m4_define([flags_load_addons], [
     m4_foreach_w([flagvar], flagvars, [
-        m4_if([flagvar], [[LIBS]], [
+        m4_if(flagvar, [LIBS], [
             $2[]flagvar[="${]$1[]flagvar[} ${]$2[]flagvar[}"]
           ], [
             $2[]flagvar[="${]$2[]flagvar[} ${]$1[]flagvar[}"]

--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,39 @@ AS_IF([test -z "$SHELL_BASH"], [
     AC_MSG_WARN([cannot find bash, which is needed by some scripts])
   ])
 
+# RPSTIR_SEARCH_LIBS is a wrapper around AC_SEARCH_LIBS to make it
+# easier to put the -l<library> flag in a variable other than LIBS.
+# Arguments:
+#   1. function:  same as in AC_SEARCH_LIBS
+#   2. search-libs:  same as in AC_SEARCH_LIBS
+#   3. [prefix]:  rather than prepend -l<library> to LIBS as in
+#      AC_SEARCH_LIBS, this macro prepends to prefixLIBS.  Defaults to
+#      "CONFIGURE_".
+#   4. [ignored-flag]:  if the -l<library> flag to prepend to
+#      prefixLIBS matches this shell 'case' statement pattern, the
+#      flag is not prepended
+#   5. [action-if-found]:  same as in AC_SEARCH_LIBS
+#   6. [action-if-not-found]:  same as in AC_SEARCH_LIBS
+#   7. [other-libraries]:  same as in AC_SEARCH_LIBS
+AC_DEFUN([RPSTIR_SEARCH_LIBS], [
+    # RPSTIR_SEARCH_LIBS
+    rpstir_save_LIBS=${LIBS}
+    AC_SEARCH_LIBS([$1], [$2], [
+        AS_VAR_PUSHDEF([rpstir_LIBS],
+          [m4_default([$3], [[CONFIGURE_]])LIBS])
+        AS_CASE([${ac_cv_search_$1}],
+          [no|""], [AC_MSG_FAILURE([assertion error])],
+          ["none required"|m4_default([$4], [""])], [],
+          [
+            AS_VAR_COPY([rpstir_tmp], [rpstir_LIBS])
+            AS_VAR_SET([rpstir_LIBS], ["${ac_cv_search_$1} ${rpstir_tmp}"])
+          ])
+        AS_VAR_POPDEF([rpstir_LIBS])
+        $5
+      ], [$6], [$7])
+    LIBS=${rpstir_save_LIBS}
+  ])
+
 ######################################################################
 # The following are helper macros to back up and restore user flag
 # variables.  User flag variables should only be temporarily modified;
@@ -228,14 +261,13 @@ AS_IF([test x${ssl_lib} != x], [
     OPENSSL_LDFLAGS="-L${ssl_lib} -Wl,-rpath -Wl,${ssl_lib}"
   ])
 flags_load_addons([[OPENSSL_]])
-AC_SEARCH_LIBS([X509_VERIFY_PARAM_free], [crypto], [], [
+RPSTIR_SEARCH_LIBS([X509_VERIFY_PARAM_free], [crypto], [OPENSSL_], [], [], [
     AC_MSG_ERROR([OpenSSL is required for building this project])
   ])
 flags_restore
 flags_load_addons([[OPENSSL_]])
-AC_SEARCH_LIBS([v3_addr_validate_path], [crypto], [
-    OPENSSL_LIBS="-lcrypto"
-  ], [
+RPSTIR_SEARCH_LIBS([v3_addr_validate_path], [crypto], [OPENSSL_],
+  ["${ac_cv_search_X509_VERIFY_PARAM_free}"], [], [
     AC_MSG_ERROR([OpenSSL with RFC 3779 is required for building this project])
   ])
 flags_restore
@@ -263,16 +295,12 @@ AS_IF([test x${odbc_lib} != x], [
     ODBC_LDFLAGS="-L${odbc_lib} -Wl,-rpath -Wl,${odbc_lib}"
   ])
 flags_load_addons([[ODBC_]])
-AC_SEARCH_LIBS([SQLWriteDSNToIni], [odbcinst iodbcinst], [
-    ODBC_LIBS="-l${ac_lib}"
-  ], [
+RPSTIR_SEARCH_LIBS([SQLWriteDSNToIni], [odbcinst iodbcinst], [ODBC_], [], [], [
     AC_MSG_ERROR([ODBC is required for building this project])
   ])
 flags_restore
 flags_load_addons([[ODBC_]])
-AC_SEARCH_LIBS([SQLConnect], [odbc iodbc], [
-    ODBC_LIBS="-l${ac_lib} ${ODBC_LIBS}"
-  ], [
+RPSTIR_SEARCH_LIBS([SQLConnect], [odbc iodbc], [ODBC_], [], [], [
     AC_MSG_ERROR([ODBC is required for building this project])
   ])
 flags_restore
@@ -302,9 +330,7 @@ AS_IF([test x${cryptlib_lib} != x], [
     CRYPTLIB_LDFLAGS="-L${cryptlib_lib} -Wl,-rpath -Wl,${cryptlib_lib}"
   ])
 flags_load_addons([[CRYPTLIB_]])
-AC_SEARCH_LIBS([cryptInit], [cl], [
-    CRYPTLIB_LIBS="-lcl"
-  ], [
+RPSTIR_SEARCH_LIBS([cryptInit], [cl], [CRYPTLIB_], [], [], [
     AC_MSG_ERROR([cryptlib is required for building this project])
   ])
 flags_restore
@@ -313,12 +339,9 @@ flags_restore
 # libdl
 ######################################################################
 flags_declare_addons([[LIBDL_]])
-AC_SEARCH_LIBS([dlopen], [dl], [
-    LIBDL_LIBS="-ldl"
-  ], [
+RPSTIR_SEARCH_LIBS([dlopen], [dl], [LIBDL_], [], [], [
     AC_MSG_ERROR([libdl is required for building this project])
   ])
-flags_restore
 
 # add all of the library-specific flags to the CONFIGURE_* flags
 #

--- a/configure.ac
+++ b/configure.ac
@@ -21,20 +21,20 @@ AC_CONFIG_MACRO_DIR([m4])
 
 AC_PATH_PROG([GIT], [git])
 AC_MSG_CHECKING([for extra version information])
-if test "x${GIT}" != x && test -x "${GIT}" && test -d "${srcdir}/.git"; then
-  PACKAGE_VERSION_FULL="$(
-    cd "${srcdir}" &&
-    ${GIT} describe --tags --long --always --dirty)"
-  if test -n "$PACKAGE_VERSION_FULL"; then
-    AC_MSG_RESULT([$PACKAGE_VERSION_FULL])
-  else
+AS_IF([test "x${GIT}" != x && test -x "${GIT}" && test -d "${srcdir}/.git"], [
+    PACKAGE_VERSION_FULL="$(
+      cd "${srcdir}" &&
+      ${GIT} describe --tags --long --always --dirty)"
+    AS_IF([test -n "$PACKAGE_VERSION_FULL"], [
+        AC_MSG_RESULT([$PACKAGE_VERSION_FULL])
+      ], [
+        PACKAGE_VERSION_FULL="$PACKAGE_VERSION"
+        AC_MSG_RESULT([failed])
+      ])
+  ], [
     PACKAGE_VERSION_FULL="$PACKAGE_VERSION"
-    AC_MSG_RESULT([failed])
-  fi
-else
-  PACKAGE_VERSION_FULL="$PACKAGE_VERSION"
-  AC_MSG_RESULT([no])
-fi
+    AC_MSG_RESULT([no])
+  ])
 AC_SUBST([PACKAGE_VERSION_FULL])
 AC_DEFINE_UNQUOTED([PACKAGE_VERSION_FULL], ["$PACKAGE_VERSION_FULL"])
 
@@ -69,9 +69,9 @@ AC_SUBST([MKTEMP])
 AC_SUBST([MKTEMP_DIR])
 
 AC_PATH_PROG([SHELL_BASH], [bash])
-if test -z "$SHELL_BASH"; then
-  AC_MSG_WARN([cannot find bash, which is needed by some scripts])
-fi
+AS_IF([test -z "$SHELL_BASH"], [
+    AC_MSG_WARN([cannot find bash, which is needed by some scripts])
+  ])
 
 ######################################################################
 # The following are helper macros to back up and restore user flag
@@ -172,24 +172,25 @@ AC_ARG_WITH(
   [mysql_config=$withval],
   [mysql_config=mysql_config])
 AC_PATH_PROG([MYSQL_CONFIG], [${mysql_config}])
-if test "x${MYSQL_CONFIG}" != x && test -x "${MYSQL_CONFIG}"; then
-  MYSQL_CPPFLAGS=$("$MYSQL_CONFIG" --include)
+AS_IF([test "x${MYSQL_CONFIG}" != x && test -x "${MYSQL_CONFIG}"], [
+    MYSQL_CPPFLAGS=$("$MYSQL_CONFIG" --include)
 
-  # this is a bit of a hack because mysql_config --libs_r specifies
-  # compiler flags, not linker flags
-  for flag in $("$MYSQL_CONFIG" --libs_r); do
-    AS_CASE([$flag],
-      [-L*], [
-        libpath=${flag#-L}
-        MYSQL_LDFLAGS="${MYSQL_LDFLAGS} -L${libpath} -Wl,-rpath -Wl,${libpath}"
-      ],
-      [-l*], [MYSQL_LIBS="${MYSQL_LIBS} ${flag}"],
-      [])
-  done
-else
-  AC_MSG_ERROR(
-    [cannot find or execute mysql_config, make sure MySQL client is installed])
-fi
+    # this is a bit of a hack because mysql_config --libs_r specifies
+    # compiler flags, not linker flags
+    for flag in $("$MYSQL_CONFIG" --libs_r); do
+      AS_CASE([$flag],
+        [-L*], [
+          libpath=${flag#-L}
+          MYSQL_LDFLAGS="${MYSQL_LDFLAGS} -L${libpath}\
+ -Wl,-rpath -Wl,${libpath}"
+        ],
+        [-l*], [MYSQL_LIBS="${MYSQL_LIBS} ${flag}"],
+        [])
+    done
+  ], [
+    AC_MSG_ERROR([cannot find or execute mysql_config,\
+ make sure MySQL client is installed])
+  ])
 AC_MSG_CHECKING([whether mysql flags are useable])
 flags_load_addons([[MYSQL_]])
 AC_LINK_IFELSE(
@@ -214,9 +215,7 @@ AC_ARG_WITH(
      /usr/local/ssl/include])],
   [ssl_include=$withval],
   [ssl_include=/usr/local/ssl/include])
-if test x${ssl_include} != x; then
-  OPENSSL_CPPFLAGS="-I${ssl_include}"
-fi
+AS_IF([test x${ssl_include} != x], [OPENSSL_CPPFLAGS="-I${ssl_include}"])
 AC_ARG_WITH(
   [ssl-lib],
   [AS_HELP_STRING(
@@ -225,9 +224,9 @@ AC_ARG_WITH(
      /usr/local/ssl/lib])],
   [ssl_lib=$withval],
   [ssl_lib=/usr/local/ssl/lib])
-if test x${ssl_lib} != x; then
-  OPENSSL_LDFLAGS="-L${ssl_lib} -Wl,-rpath -Wl,${ssl_lib}"
-fi
+AS_IF([test x${ssl_lib} != x], [
+    OPENSSL_LDFLAGS="-L${ssl_lib} -Wl,-rpath -Wl,${ssl_lib}"
+  ])
 flags_load_addons([[OPENSSL_]])
 AC_SEARCH_LIBS([X509_VERIFY_PARAM_free], [crypto], [], [
     AC_MSG_ERROR([OpenSSL is required for building this project])
@@ -252,9 +251,7 @@ AC_ARG_WITH(
     [Path to odbc include files: Defaults to /usr/local/include])],
   [odbc_include=$withval],
   [odbc_include=/usr/local/include])
-if test x${odbc_include} != x; then
-  ODBC_CPPFLAGS="-I${odbc_include}"
-fi
+AS_IF([test x${odbc_include} != x], [ODBC_CPPFLAGS="-I${odbc_include}"])
 AC_ARG_WITH(
   [odbc-lib],
   [AS_HELP_STRING(
@@ -262,9 +259,9 @@ AC_ARG_WITH(
     [Path to odbc install location: Defaults to /usr/local/lib])],
   [odbc_lib=$withval],
   [odbc_lib=/usr/local/lib])
-if test x${odbc_lib} != x; then
-  ODBC_LDFLAGS="-L${odbc_lib} -Wl,-rpath -Wl,${odbc_lib}"
-fi
+AS_IF([test x${odbc_lib} != x], [
+    ODBC_LDFLAGS="-L${odbc_lib} -Wl,-rpath -Wl,${odbc_lib}"
+  ])
 flags_load_addons([[ODBC_]])
 AC_SEARCH_LIBS([SQLWriteDSNToIni], [odbcinst iodbcinst], [
     ODBC_LIBS="-l${ac_lib}"
@@ -291,9 +288,9 @@ AC_ARG_WITH(
     [Path to cryptlib install location: Defaults to /usr/local/include])],
   [cryptlib_include=$withval],
   [cryptlib_include=/usr/local/include])
-if test x${cryptlib_include} != x; then
-  CRYPTLIB_CPPFLAGS="-I${cryptlib_include}"
-fi
+AS_IF([test x${cryptlib_include} != x], [
+    CRYPTLIB_CPPFLAGS="-I${cryptlib_include}"
+  ])
 AC_ARG_WITH(
   [cryptlib-lib],
   [AS_HELP_STRING(
@@ -301,9 +298,9 @@ AC_ARG_WITH(
     [Path to cryptlib install location: Defaults to /usr/local/lib])],
   [cryptlib_lib=$withval],
   [cryptlib_lib=/usr/local/lib])
-if test x${cryptlib_lib} != x; then
-  CRYPTLIB_LDFLAGS="-L${cryptlib_lib} -Wl,-rpath -Wl,${cryptlib_lib}"
-fi
+AS_IF([test x${cryptlib_lib} != x], [
+    CRYPTLIB_LDFLAGS="-L${cryptlib_lib} -Wl,-rpath -Wl,${cryptlib_lib}"
+  ])
 flags_load_addons([[CRYPTLIB_]])
 AC_SEARCH_LIBS([cryptInit], [cl], [
     CRYPTLIB_LIBS="-lcl"
@@ -350,21 +347,21 @@ AC_ARG_ENABLE(
     [Whether or not to add -fstack-protector to CFLAGS: Defaults
      to yes when using gcc and no otherwise])],
   [
-    if test x"$enableval" != xno; then
-      CONFIGURE_CFLAGS="${CONFIGURE_CFLAGS} -fstack-protector"
-    fi
+    AS_IF([test x"$enableval" != xno], [
+        CONFIGURE_CFLAGS="${CONFIGURE_CFLAGS} -fstack-protector"
+      ])
   ],
   [
-    if test x"$HAVE_STACK_PROTECTOR" = xyes; then
-      CONFIGURE_CFLAGS="${CONFIGURE_CFLAGS} -fstack-protector"
-    fi
+    AS_IF([test x"$HAVE_STACK_PROTECTOR" = xyes], [
+        CONFIGURE_CFLAGS="${CONFIGURE_CFLAGS} -fstack-protector"
+      ])
   ])
 
 #Check for pthreads.
 AX_PTHREAD
-if test x"$ax_pthread_ok" != xyes; then
-  AC_MSG_ERROR([pthread support is required])
-fi
+AS_IF([test x"$ax_pthread_ok" != xyes], [
+    AC_MSG_ERROR([pthread support is required])
+  ])
 CONFIGURE_LIBS="$PTHREAD_LIBS $CONFIGURE_LIBS"
 CONFIGURE_CFLAGS="$CONFIGURE_CFLAGS $PTHREAD_CFLAGS"
 CC="$PTHREAD_CC"
@@ -386,9 +383,9 @@ AC_STRUCT_TM
 
 # Checks for library functions.
 AC_CHECK_FUNCS([clock_gettime getline sem_timedwait])
-if test "$ac_cv_func_getline" != yes; then
-  AC_MSG_ERROR([The getline() function from POSIX 2008 is required.])
-fi
+AS_IF([test "$ac_cv_func_getline" != yes], [
+    AC_MSG_ERROR([The getline() function from POSIX 2008 is required.])
+  ])
 
 
 AC_CONFIG_FILES([

--- a/configure.ac
+++ b/configure.ac
@@ -150,7 +150,7 @@ m4_define([flags_load_addons], [
 # macro.
 m4_define([flags_declare_addons], [
     m4_foreach_w([flagvar], flagvars, [
-        [unset ]$1[]flagvar
+        AS_UNSET($1[]flagvar)
         AC_SUBST($1[]flagvar)
       ])
   ])

--- a/configure.ac
+++ b/configure.ac
@@ -178,17 +178,13 @@ if test "x${MYSQL_CONFIG}" != x && test -x "${MYSQL_CONFIG}"; then
   # this is a bit of a hack because mysql_config --libs_r specifies
   # compiler flags, not linker flags
   for flag in $("$MYSQL_CONFIG" --libs_r); do
-    case $flag in
-      -L*)
+    AS_CASE([$flag],
+      [-L*], [
         libpath=${flag#-L}
         MYSQL_LDFLAGS="${MYSQL_LDFLAGS} -L${libpath} -Wl,-rpath -Wl,${libpath}"
-        ;;
-      -l*)
-        MYSQL_LIBS="${MYSQL_LIBS} ${flag}"
-        ;;
-      *)
-        ;;
-    esac
+      ],
+      [-l*], [MYSQL_LIBS="${MYSQL_LIBS} ${flag}"],
+      [])
   done
 else
   AC_MSG_ERROR(

--- a/configure.ac
+++ b/configure.ac
@@ -245,44 +245,6 @@ RPSTIR_SEARCH_LIBS([dlopen], [dl], [LIBDL_], [], [], [
   ])
 
 ######################################################################
-# OpenSSL
-######################################################################
-flags_declare_addons([[OPENSSL_]])
-AC_ARG_WITH(
-  [ssl-include],
-  [AS_HELP_STRING(
-    [--with-ssl-include],
-    [Path to OpenSSL library install location: Defaults to
-     /usr/local/ssl/include])],
-  [ssl_include=$withval],
-  [ssl_include=/usr/local/ssl/include])
-AS_IF([test x${ssl_include} != x], [OPENSSL_CPPFLAGS="-I${ssl_include}"])
-AC_ARG_WITH(
-  [ssl-lib],
-  [AS_HELP_STRING(
-    [--with-ssl-lib],
-    [Path to OpenSSL library install location: Defaults to
-     /usr/local/ssl/lib])],
-  [ssl_lib=$withval],
-  [ssl_lib=/usr/local/ssl/lib])
-AS_IF([test x${ssl_lib} != x], [
-    OPENSSL_LDFLAGS="-L${ssl_lib} -Wl,-rpath -Wl,${ssl_lib}"
-  ])
-flags_load_addons([[LIBDL_]])
-flags_load_addons([[OPENSSL_]])
-RPSTIR_SEARCH_LIBS([X509_VERIFY_PARAM_free], [crypto], [OPENSSL_], [], [], [
-    AC_MSG_ERROR([OpenSSL is required for building this project])
-  ])
-flags_restore
-flags_load_addons([[LIBDL_]])
-flags_load_addons([[OPENSSL_]])
-RPSTIR_SEARCH_LIBS([v3_addr_validate_path], [crypto], [OPENSSL_],
-  ["${ac_cv_search_X509_VERIFY_PARAM_free}"], [], [
-    AC_MSG_ERROR([OpenSSL with RFC 3779 is required for building this project])
-  ])
-flags_restore
-
-######################################################################
 # ODBC
 ######################################################################
 flags_declare_addons([[ODBC_]])
@@ -345,12 +307,50 @@ RPSTIR_SEARCH_LIBS([cryptInit], [cl], [CRYPTLIB_], [], [], [
   ])
 flags_restore
 
+######################################################################
+# OpenSSL
+######################################################################
+flags_declare_addons([[OPENSSL_]])
+AC_ARG_WITH(
+  [ssl-include],
+  [AS_HELP_STRING(
+    [--with-ssl-include],
+    [Path to OpenSSL library install location: Defaults to
+     /usr/local/ssl/include])],
+  [ssl_include=$withval],
+  [ssl_include=/usr/local/ssl/include])
+AS_IF([test x${ssl_include} != x], [OPENSSL_CPPFLAGS="-I${ssl_include}"])
+AC_ARG_WITH(
+  [ssl-lib],
+  [AS_HELP_STRING(
+    [--with-ssl-lib],
+    [Path to OpenSSL library install location: Defaults to
+     /usr/local/ssl/lib])],
+  [ssl_lib=$withval],
+  [ssl_lib=/usr/local/ssl/lib])
+AS_IF([test x${ssl_lib} != x], [
+    OPENSSL_LDFLAGS="-L${ssl_lib} -Wl,-rpath -Wl,${ssl_lib}"
+  ])
+flags_load_addons([[LIBDL_]])
+flags_load_addons([[OPENSSL_]])
+RPSTIR_SEARCH_LIBS([X509_VERIFY_PARAM_free], [crypto], [OPENSSL_], [], [], [
+    AC_MSG_ERROR([OpenSSL is required for building this project])
+  ])
+flags_restore
+flags_load_addons([[LIBDL_]])
+flags_load_addons([[OPENSSL_]])
+RPSTIR_SEARCH_LIBS([v3_addr_validate_path], [crypto], [OPENSSL_],
+  ["${ac_cv_search_X509_VERIFY_PARAM_free}"], [], [
+    AC_MSG_ERROR([OpenSSL with RFC 3779 is required for building this project])
+  ])
+flags_restore
+
 # add all of the library-specific flags to the CONFIGURE_* flags
 #
 # TODO: delete this and instead reference the library-specific flag
 # variables from the appropriate *_LDFLAGS, *_LIBADD, *_LDADD,
 # *_CPPFLAGS variables in Makefile.am
-m4_foreach_w([lib], [[MYSQL] [LIBDL] [OPENSSL] [ODBC] [CRYPTLIB]], [
+m4_foreach_w([lib], [[MYSQL] [LIBDL] [ODBC] [CRYPTLIB] [OPENSSL]], [
     flags_load_addons([lib[_]], [[CONFIGURE_]])
   ])
 


### PR DESCRIPTION
A few bug fixes:

  * `-ldl` isn't necessary or available on some systems, so it shouldn't be passed on those systems
  * libcrypto depends on libdl on some systems, so the libdl flags should be loaded before checking for libcrypto
  * `m4_if()` from old versions of Autoconf seem allergic to one of the layers of quoting on the first two arguments
  * restore the library link order from before the recent cleanups merge to address some symbol conflicts between OpenSSL and cryptlib

And some cleanups.