### PR TITLE
Warning fixes

### DIFF
--- a/bin/asn1/rr.c
+++ b/bin/asn1/rr.c
@@ -229,7 +229,7 @@ int main(
     if (!isatty(0) && !isatty(1))
     {
         do_it(buf, 0, 0);
-        if (write(1, out_area.area, out_area.next) != out_area.next)
+        if ((unsigned)write(1, out_area.area, out_area.next) != out_area.next)
             abort();
         out_area.next = 0;
     }
@@ -247,7 +247,8 @@ int main(
                 FATAL(MSG_OPEN, buf);
             *buf = 0;
             do_it(buf, 0, 0);
-            if (write(1, out_area.area, out_area.next) != out_area.next)
+            if ((unsigned)write(1, out_area.area, out_area.next)
+                != out_area.next)
                 abort();
             out_area.next = 0;
         }

--- a/bin/rpki-object/make_manifest.c
+++ b/bin/rpki-object/make_manifest.c
@@ -102,7 +102,11 @@ static int gen_sha2(
     }
     cryptEncrypt(hashContext, inbufp, bsize);
     cryptEncrypt(hashContext, inbufp, 0);
-    cryptGetAttributeString(hashContext, CRYPT_CTXINFO_HASHVALUE, hash, &ansr);
+    if (cryptGetAttributeString(
+            hashContext, CRYPT_CTXINFO_HASHVALUE, hash, &ansr) != CRYPT_OK)
+    {
+        FATAL(MSG_ERROR, "calling cryptGetAttributeString()");
+    }
     cryptDestroyContext(hashContext);
     memcpy(outbufp, hash, ansr);
     return ansr;

--- a/lib/rpki-object/certificate.c
+++ b/lib/rpki-object/certificate.c
@@ -131,7 +131,14 @@ bool check_signature(
 
     cryptEncrypt(hashContext, buf, bsize);
     cryptEncrypt(hashContext, buf, 0);
-    cryptGetAttributeString(hashContext, CRYPT_CTXINFO_HASHVALUE, hash, &hash_length);
+    if (cryptGetAttributeString(
+            hashContext, CRYPT_CTXINFO_HASHVALUE, hash, &hash_length)
+        != CRYPT_OK)
+    {
+        LOG(LOG_ERR, "cryptGetAttributeString() failed");
+        ret = false;
+        goto done;
+    }
     free(buf);
 
     // get the public key from the certificate and decode it into an RSAPubKey

--- a/lib/rpki/cms/roa_validate.c
+++ b/lib/rpki/cms/roa_validate.c
@@ -75,7 +75,14 @@ check_sig(
         return ERR_SCM_CRYPTLIB;
     cryptEncrypt(hashContext, buf, bsize);
     cryptEncrypt(hashContext, buf, 0);
-    cryptGetAttributeString(hashContext, CRYPT_CTXINFO_HASHVALUE, hash, &ret);
+    if (cryptGetAttributeString(
+            hashContext, CRYPT_CTXINFO_HASHVALUE, hash, &ret) != CRYPT_OK)
+    {
+        LOG(LOG_ERR, "cryptGetAttributeString() failed");
+        free(buf);
+        cryptDestroyContext(hashContext);
+        return ERR_SCM_CRYPTLIB;
+    }
     assert(ret == 32);          /* size of hash; should never fail */
     free(buf);
 

--- a/lib/rpki/db_constants.h
+++ b/lib/rpki/db_constants.h
@@ -7,6 +7,11 @@
  *     Signature validation states
  */
 typedef enum {
+    // Use a negative value to force sigval_state to be a signed type.
+    // This prevents ancient versions of gcc from complaining with
+    // "comparison of unsigned expression < 0 is always false"
+    SIGVAL_silence_bogus_gcc_warning = -1,
+
     SIGVAL_UNKNOWN = 0,
     SIGVAL_NOTPRESENT,
     SIGVAL_VALID,

--- a/lib/util/hashutils.c
+++ b/lib/util/hashutils.c
@@ -26,7 +26,11 @@ int gen_hash(
         return -1;
     cryptEncrypt(hashContext, inbufp, bsize);
     cryptEncrypt(hashContext, inbufp, 0);
-    cryptGetAttributeString(hashContext, CRYPT_CTXINFO_HASHVALUE, hash, &ansr);
+    if (cryptGetAttributeString(
+            hashContext, CRYPT_CTXINFO_HASHVALUE, hash, &ansr) != CRYPT_OK)
+    {
+        return -1;
+    }
     cryptDestroyContext(hashContext);
     if (ansr > 0)
         memcpy(outbufp, hash, ansr);

--- a/lib/util/logging.c
+++ b/lib/util/logging.c
@@ -1,6 +1,10 @@
 #include "logging.h"
 
-struct log_custom_backend log_custom_backend = {0};
+struct log_custom_backend log_custom_backend = {
+  .log = NULL,
+  .flush = NULL,
+  .close = NULL,
+};
 
 volatile sig_atomic_t LOG_LEVEL = LOG_INFO;
 


### PR DESCRIPTION
Silence a bunch of warnings emitted by old versions of gcc and newer versions of cryptlib.