### PR TITLE
Fixes to get 'make check' and 'make distcheck' to pass

### DIFF
--- a/tests/setup_test_environment.sh.in
+++ b/tests/setup_test_environment.sh.in
@@ -31,8 +31,13 @@ case "$PROG_DIR" in
         ;;
 esac
 
-case "$PROG" in
-    *.sh)
+shebang=$(printf %s "#!" | od -t x1 -A n) || exit 1
+magic=$(od -N 2 -t x1 -A n "${PROG}") || exit 1
+case ${magic} in
+    # don't run valgrind on the interpreter, as that is unlikely to be
+    # useful, will unnecessarily slow down the tests, and will produce
+    # lots of uninteresting log output
+    "${shebang}")
         "$PROG" "$@" || exit $?
         ;;
 

--- a/tests/tap4sh.sh
+++ b/tests/tap4sh.sh
@@ -671,7 +671,7 @@ EOF
                     [ -z "${plan_on_last+set}" ] || \
                         t4s_subtests_bailout "${pfx}plan in middle of test\
  results"
-                    : "${t4s_tap_testnum=$((t4s_testnum+1))}"
+                    : ${t4s_tap_testnum=$((t4s_testnum+1))}
                     [ "${t4s_tap_testnum}" -eq $((t4s_testnum+1)) ] || \
                         t4s_subtests_bailout "${pfx}out-of-order test numbers\
  (got ${t4s_tap_testnum} expected $((t4s_testnum+1)))"


### PR DESCRIPTION
  * update `tap4sh.sh` to the latest upstream version to address issue #39 
  * don't run shell-based `*.tap` tests in valgrind